### PR TITLE
Fix Tenant filter not working with `Include()`

### DIFF
--- a/Multitenant.Interception/Infrastructure/TenantAwareAttribute.cs
+++ b/Multitenant.Interception/Infrastructure/TenantAwareAttribute.cs
@@ -30,8 +30,22 @@ namespace Multitenant.Interception.Infrastructure
                 type.MetadataProperties.SingleOrDefault(
                     p => p.Name.EndsWith(string.Format("customannotation:{0}", TenantAnnotation)));
 
-            return annotation == null ? null : (string)annotation.Value;
-        }
+            if (annotation == null)
+            {
+                var clrTypeMetadataPropName = @"http://schemas.microsoft.com/ado/2013/11/edm/customannotation:ClrType";
+                var customAnnotationValue = (Type) type.MetadataProperties.SingleOrDefault(p => p.Name == clrTypeMetadataPropName)?.Value;
 
+                if (customAnnotationValue == null)
+                {
+                    return null;
+                }
+
+                var mandantenFaehigAttribute = customAnnotationValue.CustomAttributes.SingleOrDefault(ca => ca.AttributeType.Name == nameof(MandantenFaehigAttribute));
+                var columnName = mandantenFaehigAttribute?.ConstructorArguments.FirstOrDefault();
+                return (string) columnName?.Value;
+            }
+
+            return (string) annotation.Value;
+        }
     }
 }

--- a/Multitenant.Interception/Infrastructure/TenantAwareAttribute.cs
+++ b/Multitenant.Interception/Infrastructure/TenantAwareAttribute.cs
@@ -40,8 +40,8 @@ namespace Multitenant.Interception.Infrastructure
                     return null;
                 }
 
-                var mandantenFaehigAttribute = customAnnotationValue.CustomAttributes.SingleOrDefault(ca => ca.AttributeType.Name == nameof(MandantenFaehigAttribute));
-                var columnName = mandantenFaehigAttribute?.ConstructorArguments.FirstOrDefault();
+                var tenantAwareAttribute = customAnnotationValue.CustomAttributes.SingleOrDefault(ca => ca.AttributeType.Name == nameof(TenantAwareAttribute));
+                var columnName = tenantAwareAttribute?.ConstructorArguments.FirstOrDefault();
                 return (string) columnName?.Value;
             }
 


### PR DESCRIPTION
For more information, please see comments here: http://xabikos.com/2014/11/19/Create-a-multitenant-application-with-Entity-Framework-Code-First-Part-3/

This will add missing `WHERE TenantId` for `SELECT`s with `INNER JOIN`s